### PR TITLE
No longer accidentally setting the viewport's height on orientationchange

### DIFF
--- a/src/pikabu.js
+++ b/src/pikabu.js
@@ -276,6 +276,7 @@ Mobify.$ = Mobify.$ || window.Zepto || window.jQuery;
 
         // Hide sidebars by default
         this.$sidebars['left'].addClass('m-pikabu-hidden');
+        this.$sidebars['right'].addClass('m-pikabu-hidden');
 
         // Assign it back to the instance
         this.settings = settings;
@@ -450,6 +451,7 @@ Mobify.$ = Mobify.$ || window.Zepto || window.jQuery;
         this.$element.css('marginBottom', '');
 
         this.$sidebars['left'].addClass('m-pikabu-hidden');
+        this.$sidebars['right'].addClass('m-pikabu-hidden');
 
         // Mark both sidebars as closed
         this.activeSidebar = null;


### PR DESCRIPTION
Must add the same class to both sidebars. Otherwise, on orientation
change, pikabu.js thinks that you're on a "wide-screen" device (ie. no
sidebar is active but the right sidebar is visible).
