### PR TITLE
Fix Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "plugin": "~3",
     "mobify-velocity": "1.2.2",
     "requirejs-text": "~2.0.12",
-    "requirejs": "~2.1.14",
+    "requirejs": "2.1.22",
     "bouncefix.js": "~0.3.0",
     "shade": "1.1.1",
     "lockup": "1.1.3",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "plugin": "~3",
     "mobify-velocity": "1.2.2",
     "requirejs-text": "~2.0.12",
-    "requirejs": "2.1.22",
+    "requirejs": "~2.1.15",
     "bouncefix.js": "~0.3.0",
     "shade": "1.1.1",
     "lockup": "1.1.3",

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "bouncefix.js": "~0.3.0",
     "shade": "1.1.1",
     "lockup": "1.1.3",
-    "deckard": "~1.1.0"
+    "deckard": "1.2.0"
   },
   "devDependencies": {
     "spline": "~1.0.1",

--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,12 @@
   ],
   "dependencies": {
     "plugin": "~3",
-    "mobify-velocity": "#velocity-1.2.2",
+    "mobify-velocity": "1.2.2",
     "requirejs-text": "~2.0.12",
     "requirejs": "~2.1.14",
     "bouncefix.js": "~0.3.0",
-    "shade": "#pikabu-changes",
-    "lockup": "#new-method",
+    "shade": "1.1.1",
+    "lockup": "1.1.3",
     "deckard": "~1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Some of our dependencies in Pikabu's `bower.json` point to non-existant branches, or point to branches when tagged versions will suffice. 
